### PR TITLE
Fix babelfish-updates workflow

### DIFF
--- a/.github/workflows/babelfish-updates.yml
+++ b/.github/workflows/babelfish-updates.yml
@@ -28,6 +28,7 @@ jobs:
           echo "Docker Hub tag exists: $DOCKERHUB_TAG_EXISTS"
 
   build:
+    needs: [check]
     if: needs.check.outputs.dockerhub_tag_exists == 'false'
     uses: ./.github/workflows/docker-image.yml
     secrets: inherit


### PR DESCRIPTION
Noticed that the workflow was correctly returning `Docker Hub tag exists: false` but the build job was not running.

The problem seens to be that the build job gets the value of the check step using `needs.check.outputs.dockerhub_tag_exists` without defining the needs tag 