### PR TITLE
Set password for postgres role during initial cluster initialization

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -40,6 +40,10 @@ if [ ! -f ${BABELFISH_DATA}/postgresql.conf ]; then
 		babelfishpg_tsql.migration_mode = '${MIGRATION_MODE}'
 	EOF
 	./pg_ctl -D ${BABELFISH_DATA}/ start
+
+	# Set password for postgres
+	./psql -c "ALTER USER postgres WITH PASSWORD '${PASSWORD}';"
+
 	./psql -c "CREATE USER ${USERNAME} WITH SUPERUSER CREATEDB CREATEROLE PASSWORD '${PASSWORD}' INHERIT;" \
 		-c "DROP DATABASE IF EXISTS ${DATABASE};" \
 		-c "CREATE DATABASE ${DATABASE} OWNER ${USERNAME};" \


### PR DESCRIPTION
### Summary
This PR adds a single, minimal change to start.sh to assign a password to the default PostgreSQL superuser (postgres) during initial cluster creation.
The change enables authenticated TCP connections to PostgreSQL (port 5432) using psql, while preserving all existing Babelfish behavior and startup logic.

### Motivation
The current image configures PostgreSQL to require md5 authentication for TCP connections:
```
host all all 0.0.0.0/0 md5
```

However, the postgres role is never assigned a password during initialization. As a result:

SQL Server / TDS access works (via the Babelfish user)
PostgreSQL TCP access (psql -h … -U postgres) always fails
Server‑side features such as COPY FROM '/path/file.csv' cannot be used
Sidecar-based PostgreSQL automation (CI/CD, integration tests, seeding) is blocked

Assigning a password to postgres resolves this inconsistency without changing authentication rules or startup semantics.

### What Changed
One additional SQL command is executed during the existing initialization flow:
```sql
ALTER USER postgres WITH PASSWORD '${PASSWORD}';
```

### Key characteristics of the change

✅ Runs only on first initialization (inside the existing if [ ! -f postgresql.conf ] block)
✅ Reuses the already-defined ${PASSWORD} variable
✅ Uses the existing bundled ./psql binary
✅ Does not alter:
* cluster creation logic
* Babelfish initialization
* default users, databases, or extensions
* authentication configuration (pg_hba.conf)

No other logic was modified.

### Resulting Behavior
After this change:

✅ Babelfish / SQL Server access (sqlcmd, TDS port 1433) works unchanged
✅ PostgreSQL TCP access (psql on port 5432) works as expected
✅ Server-side PostgreSQL features such as COPY are usable
✅ Enables clean sidecar-based initialization and CI workflows
✅ No impact on existing users unless they intentionally connect as postgres